### PR TITLE
Use CORS middleware

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -40,6 +40,7 @@ library:
     - text
     - uuid
     - wai
+    - wai-cors
     - warp
 
 executables:

--- a/src/SimpleRSS/ApiEndpoints.hs
+++ b/src/SimpleRSS/ApiEndpoints.hs
@@ -22,6 +22,7 @@ import Network.Wai.Handler.Warp
 import Servant
 import Servant.Swagger
 import Servant.Swagger.UI
+import Network.Wai.Middleware.Cors
 
 type API =
          SwaggerSchemaUI "docs" "swagger.json"
@@ -59,7 +60,7 @@ feedsAPI :: Proxy API
 feedsAPI = Proxy
 
 app :: ChannelMap -> Application
-app map = serve feedsAPI (server map)
+app map = simpleCors (serve feedsAPI (server map))
 
 runApp :: Port -> ChannelMap -> IO ()
 runApp port map = do


### PR DESCRIPTION
So that a frontend may utilize the API directly from a browser without
being hosted on the same domain and port.

Signed-off-by: Tobias Sjöndin <tobias.sjondin@gmail.com>